### PR TITLE
TLF-257 - ECS - Notify email to the business/caseworker and user

### DIFF
--- a/apps/ecs/behaviours/send-email-notification.js
+++ b/apps/ecs/behaviours/send-email-notification.js
@@ -1,0 +1,141 @@
+const config = require('../../../config');
+
+const NotifyClient = require('notifications-node-client').NotifyClient;
+const notifyKey = config.govukNotify.notifyApiKey;
+const notifyClient = new NotifyClient(notifyKey);
+const moment = require('moment');
+const PRETTY_DATE_FORMAT = 'DD MMMM YYYY';
+
+
+const getPersonalisation = (recipientType, req) => {
+  const basePersonalisation = {
+    business_contact_name: req.sessionModel.get('employers-contact-name'),
+    business_contact_job_title: req.sessionModel.get('contact-job-title'),
+    business_name: req.sessionModel.get('business-name'),
+    business_address: req.sessionModel.get('businessAddress'),
+    business_contact_telephone: req.sessionModel.get('contact-telephone'),
+    business_contact_email: req.sessionModel.get('contact-email-address'),
+    business_type: req.sessionModel.get('type-of-business'),
+    worker_full_name: req.sessionModel.get('worker-full-name') ??
+      req.sessionModel.get('worker-been-in-uk-before-1988-full-name'),
+    worker_date_birth: moment(req.sessionModel.get('worker-dob')).format(PRETTY_DATE_FORMAT) ??
+      moment(req.sessionModel.get('worker-been-in-uk-before-1988-dob')).format(PRETTY_DATE_FORMAT),
+    worker_nationality: req.sessionModel.get('worker-nationality') ??
+      req.sessionModel.get('worker-been-in-uk-before-1988-nationality'),
+    worker_address: req.sessionModel.get('workerAddress') ?? req.sessionModel.get('workerUkAddress'),
+    has_worker_country: req.sessionModel.get('steps').includes('/worker-address') ? 'yes' : 'no',
+    worker_country: req.sessionModel.get('worker-country') ?? '',
+    job_title: req.sessionModel.get('job-title'),
+    hours_of_work_per_week: req.sessionModel.get('hours-of-work-per-week'),
+    person_work_for_you: req.sessionModel.get('person-work-for-you'),
+    person_worked_for_you: req.sessionModel.get('person-work-for-you') === 'yes' ? 'yes' : 'no',
+    worker_start_date: req.sessionModel.get('start-work-date') ?? '',
+    work_as_result_of_tupe_transfer: req.sessionModel.get('work-for-you-result-of-tupe-transfer') ?? '',
+    result_of_tupe_transfer: req.sessionModel.get('work-for-you-result-of-tupe-transfer') === 'yes' ? 'yes' : 'no',
+    tupe_transfer_date: req.sessionModel.get('tupe-date') ?? '',
+    use_digital_right_to_work: req.sessionModel.get('use-digital-right-to-work'),
+    digital_right_to_work: req.sessionModel.get('use-digital-right-to-work') === 'no' ? 'yes' : 'no',
+    applied_for_eu_settlement: req.sessionModel.get('worker-applied-eu-settlement-scheme') ?? '',
+    has_eu_settlement: req.sessionModel.get('use-digital-right-to-work') === 'no' &&
+      req.sessionModel.get('worker-applied-eu-settlement-scheme') === 'none-of-above' ? 'yes' : 'no',
+    worker_has_arc_card: req.sessionModel.get('worker-has-arc-card') ?? '',
+    has_arc_card: req.sessionModel.get('use-digital-right-to-work') === 'no' &&
+      req.sessionModel.get('worker-has-arc-card') === 'yes' ? 'yes' : 'no',
+    seen_original_document: req.sessionModel.get('seen-original-document') ?? '',
+    arc_number: req.sessionModel.get('arc-number') ?? '',
+    not_have_arc_card: req.sessionModel.get('use-digital-right-to-work') === 'no' &&
+      req.sessionModel.get('worker-has-arc-card') === 'no' ? 'yes' : 'no',
+    worker_have_ongoing_appeal: req.sessionModel.get('worker-have-ongoing-appeal') ?? '',
+    not_have_ongoing_appeal: req.sessionModel.get('use-digital-right-to-work') === 'no' &&
+      req.sessionModel.get('worker-have-ongoing-appeal') === 'no' ? 'yes' : 'no',
+    worker_been_in_UK_before_1988: req.sessionModel.get('worker-been-in-UK-before-1988') ?? '',
+    has_worker_details_1988: req.sessionModel.get('steps').includes('/worker-details-1988') ? 'yes' : 'no',
+    place_of_birth: req.sessionModel.get('worker-place-of-birth') ?? '',
+    Year_of_entry_to_uk: req.sessionModel.get('worker-year-of-entry-to-uk') ?? '',
+    has_worker_ni_number: req.sessionModel.get('worker-national-insurance-number')?.length > 0 ? 'yes' : 'no',
+    worker_ni_number: req.sessionModel.get('worker-national-insurance-number')?.toUpperCase() ?? '',
+    has_worker_telephone: req.sessionModel.get('employer-telephone')?.length > 0 ? 'yes' : 'no',
+    worker_telephone: req.sessionModel.get('employer-telephone') ?? '',
+    has_worker_email: req.sessionModel.get('employer-email')?.length > 0 ? 'yes' : 'no',
+    worker_email: req.sessionModel.get('employer-email') ?? '',
+    has_ho_ref_number: req.sessionModel.get('steps').includes('/reference-number') ? 'yes' : 'no',
+    ho_reference_number: req.sessionModel.get('worker-reference-number') ?? ''
+  };
+  return {
+    ...basePersonalisation
+  };
+};
+
+module.exports = class SendEmailConfirmation {
+  async sendUserEmailNotification(req) {
+    const personalisations = getPersonalisation('user', req);
+
+    try {
+      await notifyClient.sendEmail(
+        config.govukNotify.userConfirmationTemplateId,
+        req.sessionModel.get('contact-email-address'),
+        {
+          personalisation: Object.assign({}, personalisations)
+        }
+      );
+
+      req.log(
+        'info',
+        'User Confirmation Email sent successfully'
+      );
+    } catch (err) {
+      const errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
+      const errorCode = err.code ? `${err.code} -` : '';
+      const errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
+
+      req.log(
+        'error',
+        'Failed to send User Confirmation Email',
+        errorMessage
+      );
+      throw  Error(errorMessage);
+    }
+  }
+
+  async sendCaseworkerEmailNotification(req) {
+    const personalisations = getPersonalisation('business', req);
+
+    try {
+      await notifyClient.sendEmail(
+        config.govukNotify.businessConfirmationTemplateId,
+        config.govukNotify.caseworkerEmail,
+        {
+          personalisation: Object.assign({}, personalisations)
+        }
+      );
+
+      req.log(
+        'info',
+        'Business Confirmation Email sent successfully'
+      );
+    } catch (err) {
+      const errorDetails = err.response?.data ? `Cause: ${JSON.stringify(err.response.data)}` : '';
+      const errorCode = err.code ? `${err.code} -` : '';
+      const errorMessage = `${errorCode} ${err.message}; ${errorDetails}`;
+
+      req.log(
+        'error',
+        'Failed to send Business Confirmation Email',
+        errorMessage
+      );
+      throw Error(errorMessage);
+    }
+  }
+
+  async send(req) {
+    try {
+      await this.sendUserEmailNotification(req);
+      await this.sendCaseworkerEmailNotification(req);
+
+      req.log('info', 'Request to send notification emails completed successfully.');
+    } catch(err) {
+      req.log('error', `Failed to send all notifications emails. ${err}`);
+      throw err;
+    }
+  }
+};

--- a/apps/ecs/behaviours/submit-notify.js
+++ b/apps/ecs/behaviours/submit-notify.js
@@ -1,0 +1,16 @@
+const SendEmailConfirmation = require('./send-email-notification');
+
+module.exports = superclass => class extends superclass {
+  async successHandler(req, res, next) {
+    const notifyEmail = new SendEmailConfirmation();
+
+    try {
+      await notifyEmail.send(req, res, super.locals(req, res));
+    } catch (error) {
+      req.log('error', 'Failed to send notification emails:', error);
+      return next(Error(`Failed to send notification emails: ${error}`));
+    }
+
+    return super.successHandler(req, res, next);
+  }
+};

--- a/apps/ecs/index.js
+++ b/apps/ecs/index.js
@@ -3,6 +3,7 @@ const Summary = hof.components.summary;
 const config = require('../../config');
 const legislativeEmploymentDate = config.legislativeEmploymentDate;
 const checkValidation = require('./behaviours/check-validation');
+const sendEmailNotification = require('./behaviours/submit-notify');
 
 module.exports = {
   name: 'ecs',
@@ -249,6 +250,7 @@ module.exports = {
       next: '/data-protection'
     },
     '/data-protection': {
+      behaviours: [sendEmailNotification],
       fields: ['privacy-check'],
       next: '/check-requested'
     },

--- a/apps/ecs/sections/summary-data-sections.js
+++ b/apps/ecs/sections/summary-data-sections.js
@@ -112,15 +112,20 @@ module.exports = {
     steps: [
       {
         step: '/worker-address',
-        field: 'worker-address-line-1'
-      },
-      {
-        step: '/worker-address',
-        field: 'worker-address-line-2'
-      },
-      {
-        step: '/worker-address',
-        field: 'worker-town-or-city'
+        field: 'worker-address-details',
+        parse: (list, req) => {
+          if (!req.sessionModel.get('steps').includes('/worker-address')) {
+            return null;
+          }
+          const workerAddressDetails = [];
+          workerAddressDetails.push(req.sessionModel.get('worker-address-line-1'));
+          if (req.sessionModel.get('worker-address-line-2')) {
+            workerAddressDetails.push(req.sessionModel.get('worker-address-line-2'));
+          }
+          workerAddressDetails.push(req.sessionModel.get('worker-town-or-city'));
+          req.sessionModel.set('workerAddress', workerAddressDetails.join(', '));
+          return workerAddressDetails.join('\n');
+        }
       },
       {
         step: '/worker-address',
@@ -128,19 +133,21 @@ module.exports = {
       },
       {
         step: '/worker-address-uk',
-        field: 'worker-uk-address-line-1'
-      },
-      {
-        step: '/worker-address-uk',
-        field: 'worker-uk-address-line-2'
-      },
-      {
-        step: '/worker-address-uk',
-        field: 'worker-uk-town-or-city'
-      },
-      {
-        step: '/worker-address-uk',
-        field: 'worker-uk-postcode'
+        field: 'worker-address-details',
+        parse: (list, req) => {
+          if (!req.sessionModel.get('steps').includes('/worker-address-uk')) {
+            return null;
+          }
+          const workerUkAddressDetails = [];
+          workerUkAddressDetails.push(req.sessionModel.get('worker-uk-address-line-1'));
+          if (req.sessionModel.get('worker-uk-address-line-2')) {
+            workerUkAddressDetails.push(req.sessionModel.get('worker-uk-address-line-2'));
+          }
+          workerUkAddressDetails.push(req.sessionModel.get('worker-uk-town-or-city'));
+          workerUkAddressDetails.push(req.sessionModel.get('worker-uk-postcode'));
+          req.sessionModel.set('workerUkAddress', workerUkAddressDetails.join(', '));
+          return workerUkAddressDetails.join('\n');
+        }
       }
     ]
   },
@@ -171,26 +178,6 @@ module.exports = {
       }
     ]
   },
-  'business-address': {
-    steps: [
-      {
-        step: '/business-address',
-        field: 'business-address-line-1'
-      },
-      {
-        step: '/business-address',
-        field: 'business-address-line-2'
-      },
-      {
-        step: '/business-address',
-        field: 'business-town-city'
-      },
-      {
-        step: '/business-address',
-        field: 'business-postcode'
-      }
-    ]
-  },
   'employer-contact-details': {
     steps: [
       {
@@ -216,6 +203,24 @@ module.exports = {
       {
         step: '/employer-contact-details',
         field: 'contact-email-address'
+      },
+      {
+        step: '/business-address',
+        field: 'business-address-details',
+        parse: (list, req) => {
+          if (!req.sessionModel.get('steps').includes('/business-address')) {
+            return null;
+          }
+          const businessAddressDetails = [];
+          businessAddressDetails.push(req.sessionModel.get('business-address-line-1'));
+          if (req.sessionModel.get('business-address-line-2')) {
+            businessAddressDetails.push(req.sessionModel.get('business-address-line-2'));
+          }
+          businessAddressDetails.push(req.sessionModel.get('business-town-city'));
+          businessAddressDetails.push(req.sessionModel.get('business-postcode'));
+          req.sessionModel.set('businessAddress', businessAddressDetails.join(', '));
+          return businessAddressDetails.join('\n');
+        }
       }
     ]
   }

--- a/config.js
+++ b/config.js
@@ -12,5 +12,11 @@ module.exports = {
     port: process.env.REDIS_PORT || '6379',
     host: process.env.REDIS_HOST || '127.0.0.1'
   },
-  legislativeEmploymentDate: '2008-02-29'
+  legislativeEmploymentDate: '2008-02-29',
+  govukNotify: {
+    notifyApiKey: process.env.NOTIFY_KEY,
+    caseworkerEmail: process.env.CASEWORKER_EMAIL,
+    userConfirmationTemplateId: process.env.USER_CONFIRMATION_TEMPLATE_ID,
+    businessConfirmationTemplateId: process.env.BUSINESS_CONFIRMATION_TEMPLATE_ID
+  }
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "start:dev": "hof-build watch",
+    "start:dev": "hof-build watch --env",
     "build": "hof-build",
     "postinstall": "hof-build",
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/UKHomeOffice/ecs#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.0",
-    "hof": "^20.5.2"
+    "hof": "^20.5.2",
+    "notifications-node-client": "^8.2.0"
   },
   "devDependencies": {
     "chai": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,6 +746,15 @@ axios@^0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
+axios@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1267,7 +1276,7 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2366,7 +2375,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.7:
+follow-redirects@^1.14.7, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -2390,6 +2399,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -3916,6 +3934,14 @@ notifications-node-client@^6.0.0:
     axios "^0.25.0"
     jsonwebtoken "^9.0.0"
 
+notifications-node-client@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/notifications-node-client/-/notifications-node-client-8.2.0.tgz#1fe0814a0b5e6732939ca91c34b11e5c1176605f"
+  integrity sha512-XGmW2f2CroEwIUrPaTyShpF8pLlu79rBnwWns1uPGs27LbZdzNPJF1BzPl3cG3Tsu3nVlaWeXJJYAE+ALryalA==
+  dependencies:
+    axios "^1.6.1"
+    jsonwebtoken "^9.0.0"
+
 nyc@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.1.0.tgz#1335dae12ddc87b6e249d5a1994ca4bdaea75f02"
@@ -4257,6 +4283,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.9.0"


### PR DESCRIPTION
## What? 
TLF-257 - ECS - Notify email to the business/caseworker and user [TLF-257](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-257)

## Why? 
Allow user and business to receive a confirmation email on form submission.

## How? 
Confirmation emails are sent using the NotifyClient from the [notifications-node-client](https://www.npmjs.com/package/notifications-node-client) package. This is done in the sendUserEmailNotification and sendCaseworkerEmailNotification methods of the send-email-notification class.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)