### PR TITLE
Add env variable stag to .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,7 @@ type: kubernetes
 environment:
   APP_NAME: ecs
   PROD_ENV: sas-ecs-prod
+  STG_ENV: sas-ecs-stg
   UAT_ENV: sas-ecs-uat
   BRANCH_ENV: sas-ecs-branch
   PRODUCTION_URL: www.employer-request-a-check.homeoffice.gov.uk


### PR DESCRIPTION
What
Add STG_ENV: sas-ecs-stg to .drone.yml as the feature branch pipeline is failing when clone the hof-service files with staging
Why
We have added the staging environment to the master branch and the hof-service-config files so the branch is failing as it need the environment variable to be defined
How
Add STG_ENV: sas-ecs-stg to .drone.yml file