### PR TITLE
TLF-293-changed the validation message for the zipcode

### DIFF
--- a/apps/ecs/translations/src/en/validation.json
+++ b/apps/ecs/translations/src/en/validation.json
@@ -187,7 +187,7 @@
   "worker-zipcode": {
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "Postal code or ZIP code must be 10 characters or less",
-    "zipCode":"Postal code must only include letters a-z, numbers, spaces and dashes"
+    "zipCode":"Postal or ZIP code must only include letters a-z, numbers, spaces and dashes"
   },
   "worker-country": {
     "required": "Enter the country the worker's address is in",


### PR DESCRIPTION
### What
TLF-293 - ECS - zipcode validation error message- 
[TLF-293](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-293)
[TLF-294](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-294)

### Why
- changed the zipcode validation as per spreadsheet

### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local