### PR TITLE
Fixed spelling in Right to work check eligibility

### DIFF
--- a/apps/ecs/translations/src/en/pages.json
+++ b/apps/ecs/translations/src/en/pages.json
@@ -4,7 +4,7 @@
     "right-to-work-intro": "You do not need to use this service if the worker has any of the following: ",
     "worker-has-ppt": "a UK or Irish passport (or Irish passport card)",
     "worker-has-ho-docs": "immigration documents from the Home Office that demonstrate a right to work",
-    "worker-has-digital-right": "a digital immigration satus that demonstrates a right to work"
+    "worker-has-digital-right": "a digital immigration status that demonstrates a right to work"
   },
   "ineligible": {
     "header": "You do not need to request a Home Office right to work check",


### PR DESCRIPTION
## What? 
Incorrect spelling of status in Right to work check eligibility
## Why? 
## How? 
Local
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
