### PR TITLE
TLF-320: Changes to notify email to business

### DIFF
--- a/apps/ecs/behaviours/send-email-notification.js
+++ b/apps/ecs/behaviours/send-email-notification.js
@@ -16,11 +16,11 @@ const getLabel = (fieldKey, fieldValue) => {
 const getPersonalisation = (recipientType, req) => {
   const isTupeTransferEligible = req.sessionModel.get('person-work-for-you') === 'yes' &&
     req.sessionModel.get('start-work-date') < config.legislativeEmploymentDate ? 'yes' : 'no';
+
   const basePersonalisation = {
     business_contact_name: req.sessionModel.get('employers-contact-name'),
     business_contact_job_title: req.sessionModel.get('contact-job-title'),
     business_name: req.sessionModel.get('business-name'),
-    business_address: req.sessionModel.get('businessAddress'),
     business_contact_telephone: req.sessionModel.get('contact-telephone'),
     business_contact_email: req.sessionModel.get('contact-email-address'),
     business_type: req.sessionModel.get('type-of-business'),
@@ -30,7 +30,6 @@ const getPersonalisation = (recipientType, req) => {
       moment(req.sessionModel.get('before-1988-worker-dob')).format(config.PRETTY_DATE_FORMAT),
     worker_nationality: req.sessionModel.get('worker-nationality') ??
       req.sessionModel.get('before-1988-worker-nationality'),
-    worker_address: req.sessionModel.get('workerAddress') ?? req.sessionModel.get('workerUkAddress'),
     has_worker_country: req.sessionModel.get('steps').includes('/worker-address') ? 'yes' : 'no',
     worker_country: req.sessionModel.get('worker-country') ?? '',
     job_title: req.sessionModel.get('job-title'),
@@ -82,9 +81,37 @@ const getPersonalisation = (recipientType, req) => {
     has_ho_ref_number: req.sessionModel.get('steps').includes('/reference-number') ? 'yes' : 'no',
     ho_reference_number: req.sessionModel.get('worker-reference-number')?.toUpperCase() ?? ''
   };
-  return {
-    ...basePersonalisation
-  };
+
+  const dynamicProps = {};
+
+  if (recipientType === 'user') {
+    dynamicProps.business_address = req.sessionModel.get('businessAddress');
+    dynamicProps.worker_address = req.sessionModel.get('workerAddress') ?? req.sessionModel.get('workerUkAddress');
+
+  }
+
+  if (recipientType === 'business') {
+    dynamicProps.business_address_line_1 = req.sessionModel.get('business-address-line-1');
+    dynamicProps.business_address_line_2 = req.sessionModel.get('business-address-line-2') ?? '';
+    dynamicProps.business_address_town_city = req.sessionModel.get('business-town-city');
+    dynamicProps.business_address_postcode = req.sessionModel.get('business-postcode');
+
+    if (req.sessionModel.get('workerAddress')) {
+      dynamicProps.worker_address_line_1 = req.sessionModel.get('worker-address-line-1');
+      dynamicProps.worker_address_line_2 = req.sessionModel.get('worker-address-line-2') ?? '';
+      dynamicProps.worker_address_town_city = req.sessionModel.get('worker-town-or-city');
+      dynamicProps.worker_address_postcode = req.sessionModel.get('worker-zipcode') ?? '';
+    }
+
+    if (req.sessionModel.get('workerUkAddress')) {
+      dynamicProps.worker_address_line_1 = req.sessionModel.get('worker-uk-address-line-1');
+      dynamicProps.worker_address_line_2 = req.sessionModel.get('worker-uk-address-line-2') ?? '';
+      dynamicProps.worker_address_town_city = req.sessionModel.get('worker-uk-town-or-city');
+      dynamicProps.worker_address_postcode = req.sessionModel.get('worker-uk-postcode');
+    }
+  }
+
+  return Object.assign(basePersonalisation, dynamicProps);
 };
 
 module.exports = class SendEmailConfirmation {

--- a/apps/ecs/behaviours/send-email-notification.js
+++ b/apps/ecs/behaviours/send-email-notification.js
@@ -87,7 +87,6 @@ const getPersonalisation = (recipientType, req) => {
   if (recipientType === 'user') {
     dynamicProps.business_address = req.sessionModel.get('businessAddress');
     dynamicProps.worker_address = req.sessionModel.get('workerAddress') ?? req.sessionModel.get('workerUkAddress');
-
   }
 
   if (recipientType === 'business') {


### PR DESCRIPTION
## What?

[TLF-320](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-320)
Alters the preparation of personalisation object passed to GovUK Notify templates related to addresses.

- Addresses are assigned to base personalisation object dynamically based on `recipientType`
- Employer email template receives addresses where the address fields were concatenated. This is reflected in the Notify template.
- Business email template receives addresses as 4 separate lines (Address line 1, line 2, town/city and postcode). The business submission Notify template has also been updated to accept these different values

## Why?

Notify emails sent to the business mailbox are further processed by automation tools to consume form values into another system. For this reason it is easier for them to have addresses as four separate values in the business submission Notify email than in one concatenated field.

For employer users, their email can still concatenate the addresses, as this is more easily readable for them.

## How? 

Extracted the generic address params from the `basePersonalisation` object as part of the `getPersonalisation` method and assign them dynamically to a `dynamicProps` object instead. Return a merged object of `basePersonalisation` and `dynamicParams`