### PR TITLE
TLF-331 - ECS - Added replyToEmailID in the send email method

### DIFF
--- a/apps/ecs/behaviours/send-email-notification.js
+++ b/apps/ecs/behaviours/send-email-notification.js
@@ -163,11 +163,13 @@ module.exports = class SendEmailConfirmation {
       const targetTemplate = `${recipientType}ConfirmationTemplateId`;
       const targetEmailAddress = recipientType === 'user' ?
         this.req.sessionModel.get('contact-email-address') : config.govukNotify.caseworkerEmail;
+      const emailReplyToId = config.govukNotify.replyToEmailID;
       await notifyClient.sendEmail(
         config.govukNotify[targetTemplate],
         targetEmailAddress,
         {
-          personalisation: recipientType === 'user' ? this.userEmailPersonalisation : this.businessEmailPersonalisation
+          personalisation: recipientType === 'user' ? this.userEmailPersonalisation : this.businessEmailPersonalisation,
+          emailReplyToId: emailReplyToId
         }
       );
 

--- a/config.js
+++ b/config.js
@@ -17,7 +17,8 @@ module.exports = {
     notifyApiKey: process.env.NOTIFY_KEY,
     caseworkerEmail: process.env.CASEWORKER_EMAIL,
     userConfirmationTemplateId: process.env.USER_CONFIRMATION_TEMPLATE_ID,
-    businessConfirmationTemplateId: process.env.BUSINESS_CONFIRMATION_TEMPLATE_ID
+    businessConfirmationTemplateId: process.env.BUSINESS_CONFIRMATION_TEMPLATE_ID,
+    replyToEmailID: process.env.REPLY_TO_EMAIL_ID
   },
   PRETTY_DATE_FORMAT: 'DD MMMM YYYY'
 };


### PR DESCRIPTION
## What?
- [TLF-331](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-331)
- [TLF-332](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-332)
- Added the reply to email id in gov notify

## Why?
- We are using existing gov notify service for ECS and LCS and the default reply to email address in the service cannot be used for HOF emails.
- So added one more reply to email address in gov notify settings and referred that value from hof-services-config

## How? 
- Added the email unique identifier value in hof-services-config and referred in config.js.
- Reading the replyToEmailID value from config and mapped to the emailReplyToId in sendEmail method in notifyClient


### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local