### PR TITLE
TLF-169: remove duplication in redis-network-policy

### DIFF
--- a/kube/redis/redis-network-policy.yml
+++ b/kube/redis/redis-network-policy.yml
@@ -16,13 +16,6 @@ spec:
           {{ else }}
           name: {{ .APP_NAME }}
           {{ end }}
-    - podSelector:
-        matchLabels:
-          {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-          name: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}
-          {{ else }}
-          name: {{ .APP_NAME }}
-          {{ end }}
     ports:
     - port: 6379
       protocol: TCP


### PR DESCRIPTION
What
Remove duplication in the redis-network-policy.yml podselector. 
Why
There is not needed
How
Removing the code that duplicate the podSelector