### PR TITLE
TLF-358 - ECS - added United Kingdom and Ireland options for worker-country field 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The `.devcontainer` folder contains the necessary configuration files for the de
 
 ### Prerequisites
    - [Docker](https://www.docker.com)
-   - [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extention
+   - [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
 
 ### Setup
 
@@ -79,7 +79,7 @@ By following these steps, you should be able to run your application using a dev
 
 1. Make sure you have Docker installed and running on your machine. Docker is needed to create and manage your containers.
 
-2. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extention in VS Code. This extension allows you to develop inside a containerised environment.
+2. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VS Code. This extension allows you to develop inside a containerised environment.
 
 3. To configure your dev environment, copy `/.devcontainer/devcontainer.env.sample` to `devcontainer.env` in the same directory and fill in the necessary values. This ensures your development container is set up with the required environment variables.
 

--- a/apps/ecs/behaviours/check-validation.js
+++ b/apps/ecs/behaviours/check-validation.js
@@ -14,8 +14,7 @@ module.exports = superclass => class extends superclass {
       }
     }
 
-    if(key === 'before-1988-worker-nationality' || key === 'worker-country' ||
-     key === 'worker-nationality') {
+    if(key === 'before-1988-worker-nationality' || key === 'worker-nationality') {
       if(req.form.values[key] === 'United Kingdom' || req.form.values[key] === 'Ireland') {
         return validationErrorFunc('excludeUkIr');
       }
@@ -23,6 +22,9 @@ module.exports = superclass => class extends superclass {
 
     if(key === 'before-1988-worker-dob') {
       const workerDob = req.form.values[key];
+      if (!validators.date(workerDob)) {
+        return validationErrorFunc('date');
+      }
       if (moment(workerDob).isSameOrAfter('1988-01-01')) {
         return validationErrorFunc('afterDobYear');
       }

--- a/apps/ecs/fields/index.js
+++ b/apps/ecs/fields/index.js
@@ -229,7 +229,7 @@ module.exports = {
   'before-1988-worker-dob': dateComponent('before-1988-worker-dob', {
     mixin: 'input-date',
     validate: [
-      'required', 'date',
+      'required',
       { type: 'before', arguments: ['16', 'years']},
       { type: 'after', arguments: ['120', 'years']}
     ]
@@ -293,7 +293,7 @@ module.exports = {
         value: '',
         label: 'fields.worker-country.options.null'
       }
-    ].concat(countries.filter(country => !['Ireland', 'United Kingdom'].includes(country.value)))
+    ].concat(countries)
   },
   'worker-uk-address-line-1': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],

--- a/apps/ecs/translations/src/en/validation.json
+++ b/apps/ecs/translations/src/en/validation.json
@@ -55,7 +55,8 @@
   "worker-dob": { 
     "required": "Enter the worker's date of birth",
     "before": "The worker must be 16 years or older – this service only applies to workers aged 16 or over",
-    "after": "Enter a real date of birth"
+    "after": "Enter a real date of birth",
+    "date": "Enter a real date of birth"
   },
   "worker-nationality": {
     "required": "Enter a country of nationality",
@@ -138,6 +139,7 @@
   },
   "before-1988-worker-dob": {
     "required": "Enter the worker's date of birth",
+    "date": "Enter a real date of birth",
     "before": "The worker must be 16 years or over – this service only applies to workers aged 16 or over",
     "after": "Enter a real date of birth",
     "afterDobYear": "Worker's date of birth must be before 1988, when they came to the UK"
@@ -191,8 +193,7 @@
   },
   "worker-country": {
     "required": "Enter the country the worker's address is in",
-    "maxlength": "Country must be between 1 and 250 characters",
-    "excludeUkIr": "You do not need to request a Home Office right to work check if you are a UK or Ireland Citizen"
+    "maxlength": "Country must be between 1 and 250 characters"
   },
   "worker-uk-address-line-1": {
     "required": "Enter address line 1, typically the building and street",


### PR DESCRIPTION
## What?
- [TLF-358](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-358)
- add United Kingdom and Ireland to the Country in worker-address page

## Why?
- Currently the Country field on /worker-address page uses the same type ahead as the Country of Nationality field but for Country we need to make sure United Kingdom and Ireland are options for the address page

## How? 
- added all options from  hof countries for worker-country field in worker-address page and removed the filter for United Kingdom and Ireland
- And added date validation for worker dob field


### Testing
- [x] Local testing passed
- [x] Test Lint Passed in Local