### PR TITLE
ECS-89: Increase memory allocation to ecs container

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -96,10 +96,10 @@ spec:
           resources:
             requests:
               cpu: "20m"
-              memory: "100Mi"
+              memory: "256Mi"
             limits:
               cpu: "100m"
-              memory: "200Mi"
+              memory: "512Mi"
           volumeMounts:
             - mountPath: /public
               name: public


### PR DESCRIPTION
## What?

* Increasing to fix Pod restarts with OOM
* At the Pod restart time Memory consumption is 246MiB exceeding the limit of 200MiB.
* Using powers of 2 allows for more efficient memory addressing and alignment. For example, a memory block of 256 bytes can be easily divided into 128, 64, 32, etc., which simplifies memory allocation and access.
* In binary, memory sizes are typically powers of 2
* https://collaboration.homeoffice.gov.uk/jira/browse/ECS-89

## Why?

* Pod Restarts issue has been addressed 
* On the same day of restarts It consumed 246MiB of memory exceeding the limit of 200MiB.
* None of Application issues addressed
* Allocating extra memory will resolve the pod restart issue

## How?

* Updated Memory limits and requests to 512 and 256. MiB. 


## Testing?
* Monitored using sysdig.
* Added a new panel to display percentage of memory limits utilized by container

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
