### PR TITLE
ECS-73 Clear old worker data when editing from summary page

### DIFF
--- a/apps/ecs/behaviours/clear-worker-details.js
+++ b/apps/ecs/behaviours/clear-worker-details.js
@@ -1,0 +1,37 @@
+module.exports = superclass => class extends superclass {
+  saveValues(req, res, next) {
+    const fields = Object.keys(req.form.options.fields || {});
+    const editing1988 = fields.some(f => f.startsWith('before-1988-'));
+
+    if (editing1988) {
+      req.sessionModel.unset([
+        'worker-full-name',
+        'worker-dob',
+        'worker-nationality',
+        'worker-address-line-1',
+        'worker-address-line-2',
+        'worker-town-or-city',
+        'worker-zipcode',
+        'worker-country',
+        'worker-uk-address-line-1',
+        'worker-uk-address-line-2',
+        'worker-uk-town-or-city',
+        'worker-uk-postcode',
+        'worker-reference-number'
+      ]);
+    } else {
+      req.sessionModel.unset([
+        'before-1988-worker-full-name',
+        'before-1988-worker-dob',
+        'before-1988-worker-nationality',
+        'before-1988-worker-place-of-birth',
+        'before-1988-worker-year-of-entry-to-uk',
+        'before-1988-worker-national-insurance-number',
+        'before-1988-employer-telephone',
+        'before-1988-employer-email'
+      ]);
+    }
+
+    super.saveValues(req, res, next);
+  }
+};

--- a/apps/ecs/index.js
+++ b/apps/ecs/index.js
@@ -5,6 +5,8 @@ const legislativeEmploymentDate = config.legislativeEmploymentDate;
 const checkValidation = require('./behaviours/check-validation');
 const sendEmailNotification = require('./behaviours/submit-notify');
 const saveSession = require('./behaviours/save-session');
+const ClearWorkerDetails = require('./behaviours/clear-worker-details');
+
 
 module.exports = {
   name: 'ecs',
@@ -152,7 +154,7 @@ module.exports = {
       continueOnEdit: true
     },
     '/worker-details-1988': {
-      behaviours: [checkValidation],
+      behaviours: [checkValidation, ClearWorkerDetails],
       fields: [
         'before-1988-worker-full-name',
         'before-1988-worker-dob',
@@ -214,7 +216,7 @@ module.exports = {
     },
     '/worker-details': {
       continueOnEdit: true,
-      behaviours: [checkValidation],
+      behaviours: [checkValidation, ClearWorkerDetails],
       fields: [
         'worker-full-name',
         'worker-dob',


### PR DESCRIPTION
## What? 
[ECS-73](https://collaboration.homeoffice.gov.uk/jira/browse/ECS-73 - Clear old worker data when editing from summary page

## Why? 
Duplication of users or addition would confuse both the user and the business. 

## How? 
- Added a new behaviour (clear-worker-details.js) that cleans up the “other” set of worker details whenever a user saves values.

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
