### PR TITLE
HOFF-2008 adding sonar to make sure pipeline runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,8 +40,8 @@ unit_tests: &unit_tests
     - yarn run test:unit
 
 sonar_scanner: &sonar_scanner
-  pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
+  pull: always
+  image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 


### PR DESCRIPTION
## What?
This pull request updates the SonarQube scanner configuration in the `.drone.yml` file to ensure the latest scanner image is always used and to switch to a more general scanner image.

CI/CD pipeline improvements:

* Changed the `sonar_scanner` step in `.drone.yml` to always pull the latest image (`pull: always`) instead of only if it doesn't exist (`pull: if-not-exists`).
* Updated the scanner image from `quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest` to `quay.io/ukhomeofficedigital/sonar-scanner:latest`, moving away from the Node.js-specific image.
## Why?
## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
